### PR TITLE
Fix podspec

### DIFF
--- a/AsyncKingfisher.podspec
+++ b/AsyncKingfisher.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.12"
   s.watchos.deployment_target = "3.0"
 
-  s.source       = { :git => "https://github.com/faberNovel/Kingfisher.git", :tag => s.version }
+  s.source       = { :git => "https://github.com/faberNovel/Kingfisher.git", :tag => "v#{s.version}" }
 
   s.default_subspecs = "Core"
 


### PR DESCRIPTION
Renamed Kingfisher.podspec to AsyncKingfisher.podspec.
Changed version tag format from x.y.z to vx.y.z to prevent conflict with releases from the original pod.